### PR TITLE
Fix broken Prism stylesheet URL in blog post

### DIFF
--- a/blog/2015-03-01.html
+++ b/blog/2015-03-01.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2016-04-13.html
+++ b/blog/2016-04-13.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2016-04-27.html
+++ b/blog/2016-04-27.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2016-05-26.html
+++ b/blog/2016-05-26.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2016-05-28.html
+++ b/blog/2016-05-28.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2016-06-26.html
+++ b/blog/2016-06-26.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2016-07-06.html
+++ b/blog/2016-07-06.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2016-08-31.html
+++ b/blog/2016-08-31.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2016-10-03.html
+++ b/blog/2016-10-03.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2016-11-01.html
+++ b/blog/2016-11-01.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2016-11-10.html
+++ b/blog/2016-11-10.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2017-03-27.html
+++ b/blog/2017-03-27.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2017-04-02.html
+++ b/blog/2017-04-02.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2017-04-12.html
+++ b/blog/2017-04-12.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2017-05-09.html
+++ b/blog/2017-05-09.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2017-06-27.html
+++ b/blog/2017-06-27.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2017-12-05.html
+++ b/blog/2017-12-05.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2018-03-02.html
+++ b/blog/2018-03-02.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2018-04-05.html
+++ b/blog/2018-04-05.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2018-05-24.html
+++ b/blog/2018-05-24.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2018-06-22.html
+++ b/blog/2018-06-22.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2018-10-02.html
+++ b/blog/2018-10-02.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 

--- a/blog/2021-04-07-publish-grails-plugin-to-maven-central.html
+++ b/blog/2021-04-07-publish-grails-plugin-to-maven-central.html
@@ -29,7 +29,7 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.orghttps://grails.apache.org/stylesheets/prism.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/prism.css'/>
     <script src='https://grails.apache.org/javascripts/prism.js'></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 


### PR DESCRIPTION
This PR fixes a broken stylesheet URL in a Grails blog post
from March 1, 2015 where the Prism CSS link contained a duplicated
domain, resulting in a 404.

Fixes #6
