### PR TITLE
fixed issue 7

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -4,3 +4,15 @@ ErrorDocument 404 /404.html
 # CSP permissions for grails.apache.org - https://issues.apache.org/jira/browse/INFRA-27297
 # Ref https://docs.kapa.ai/integrations/understanding-csp-cors
 SetEnv CSP_PROJECT_DOMAINS "https://*.kapa.ai/ https://kapa-widget-proxy-la7dkmplpq-uc.a.run.app https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://hcaptcha.com https://*.hcaptcha.com"
+
+# Legacy Documentation Redirects
+RedirectMatch 301 ^/docs-legacy-gorm/latest/.* https://grails.apache.org/docs/latest/grails-data/
+RedirectMatch 301 ^/docs-legacy-gorm/snapshot/.* https://grails.apache.org/docs/snapshot/grails-data/
+RedirectMatch 301 ^/docs-legacy-async/latest/.* https://grails.apache.org/docs/latest/guide/async.html
+RedirectMatch 301 ^/docs-legacy-async/snapshot/.* https://grails.apache.org/docs/snapshot/guide/async.html
+RedirectMatch 301 ^/docs-legacy-gsp/latest/.* https://grails.apache.org/docs/latest/guide/theWebLayer.html#gsp
+RedirectMatch 301 ^/docs-legacy-gsp/snapshot/.* https://grails.apache.org/docs/snapshot/guide/theWebLayer.html#gsp
+RedirectMatch 301 ^/docs-legacy-testing/latest/.* https://grails.apache.org/docs/latest/guide/testing.html
+RedirectMatch 301 ^/docs-legacy-testing/snapshot/.* https://grails.apache.org/docs/snapshot/guide/testing.html
+RedirectMatch 301 ^/docs-legacy-views/latest/.* https://grails.apache.org/docs/latest/guide/theWebLayer.html#gson
+RedirectMatch 301 ^/docs-legacy-views/snapshot/.* https://grails.apache.org/docs/snapshot/guide/theWebLayer.html#gson


### PR DESCRIPTION
## Issue:
The previous method used a "meta-refresh" tag inside index.html
. This only redirected people who landed exactly on index.html
. If someone clicked a link to a specific page inside that folder `(e.g., .../latest/api/SomeClass.html),` they would not be redirected and might see a 404 error or outdated content.

## Changes I made:
I configured RedirectMatch rules in the 
`.htaccess` file. This tells the web server to catch any request and immediately redirect it to the new location.

## Files changed:
`grails-website/.htaccess`

This PR fixed issue #7 