### PR TITLE
Fix invalid stylesheet link in blog tag pageUpdate angular.html

### DIFF
--- a/blog/tag/angular.html
+++ b/blog/tag/angular.html
@@ -27,7 +27,6 @@
     <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://grails.apache.org/javascripts/paginate.js'></script>
     
-    <link rel='stylesheet' href='https://grails.apache.org'/>
     <script src=''></script>
     <script src='https://grails.apache.org/javascripts/plugins.js'></script>
 


### PR DESCRIPTION
Removed an invalid stylesheet reference (https://grails.apache.org) which does not point to a valid CSS resource.

The page already includes proper stylesheet files, so this link appears unnecessary.